### PR TITLE
Move nbsphinx-link to pip dependencies

### DIFF
--- a/envs/pypsa-gb-stable.yaml
+++ b/envs/pypsa-gb-stable.yaml
@@ -88,7 +88,6 @@ dependencies:
 - sphinx-design=0.6.1
 - sphinxcontrib-mermaid=1.2.3
 - nbsphinx=0.9.8
-- nbsphinx-link=1.3.1
 - pandoc=3.8.3
 - docutils=0.21.2
 
@@ -105,3 +104,4 @@ dependencies:
   - highspy==1.12.0
   - tsam==2.3.9
   - entsoe-py==0.7.8
+  - nbsphinx-link==1.3.1


### PR DESCRIPTION
## Summary

Moves `nbsphinx-link` from the conda dependencies to the pip dependencies in `pypsa-gb-stable.yaml`.

## Motivation

On Windows, environment creation fails because `nbsphinx-link=1.3.1` is not available through the conda channels specified in the environment file.

Installing it via pip allows the environment to be created successfully while preserving the required package version.

## Testing

- Successfully created the `pypsa-gb-stable` environment on Windows.
- Ran `snakemake -n` successfully.
- Executed a real workflow run successfully until the workflow reached the ENTSO-E API token requirement.