### PR TITLE
Change default interconnector pricing source to derived

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -992,7 +992,7 @@ subsidy_tracking:
 #   pricing signals for accurate wholesale price reporting.
 interconnectors:
   pricing:
-    source: "entsoe"                 # "derived" | "entsoe" | "csv"
+    source: "derived"                 # "derived" | "entsoe" | "csv"
     eur_to_gbp: 0.86                # EUR→GBP conversion rate
     gb_price: 50.0                   # GB wholesale price for price differentials (£/MWh)
     price_floor: 0.0                # Minimum EU price (£/MWh)


### PR DESCRIPTION
**Summary**

This PR changes the default interconnector pricing source from entsoe to derived.

**Motivation**

The previous default required an **ENTSO-E API token** even when running the standard workflow with market simulation disabled. During testing, the workflow attempted to **fetch ENTSO-E day-ahead prices** through the interconnector module and failed when no API token was available.

Changing the default to derived removes this dependency and allows new users to run the model without additional configuration.

**Changes**

- Updated **config/defaults.yaml**
- Changed the default interconnector pricing source from entsoe to derived
- Testing
- Tested **HT35** with **market.enabled: false**
- Confirmed that the workflow no longer attempts to fetch **ENTSO-E** prices
- Confirmed successful completion of the full workflow.