### PR TITLE
Feature/nuclear operation

### DIFF
--- a/config/defaults.yaml
+++ b/config/defaults.yaml
@@ -16,7 +16,7 @@ voll: 6000.0                      # Value of Lost Load (£/MWh)
 # SOLVER CONFIGURATION
 # ──────────────────────────────────────────────────────────────────────────────
 solver:
-  name: "gurobi"                  # Options: gurobi, highs, glpk, cplex
+  name: "highs"                  # Options: gurobi, highs, glpk, cplex
   threads: 4
   method: 2                       # 0=primal, 1=dual, 2=barrier
   crossover: 0                    # 0=disabled (faster), -1=auto (enables crossover)
@@ -1195,3 +1195,14 @@ demand_flexibility:
     max_reduction_fraction: 0.10      # Fallback: max demand reduction per event (10%)
     marginal_cost: 100.0              # DSR incentive payment (£/MWh) - high cost = only dispatch if needed
     winter_months: [10, 11, 12, 1, 2, 3]  # Oct-Mar for winter mode
+
+    # ──────────────────────────────────────────────────────────────────────────────
+    # NUCLEAR CONFIGURATION
+    # ──────────────────────────────────────────────────────────────────────────────
+    # Ensure default nuclear generators are configured to baseload.
+    # Only change if explicitly testing nuclear load following.
+    nuclear_operation:
+      enabled: false
+      min_output: null
+      ramp_limit: null
+

--- a/docs/source/user_guide/configuration.md
+++ b/docs/source/user_guide/configuration.md
@@ -158,6 +158,12 @@ demand_flexibility:
     enabled: false
     mode: "both"
     dsr_capacity_mw: 5000
+
+# Nuclear operation defaults
+nuclear_operation:
+  enabled: false
+  min_output: null
+  ramp_limit: null
 ```
 
 ## Key Parameters
@@ -281,6 +287,47 @@ timestep_minutes: 60  # or 30
 ```
 
 Half-hourly (30 min) doubles computation time but captures faster dynamics.
+
+### Nuclear Generator Operation
+
+Scenario-specific nuclear operating constraints can be configured under
+`nuclear_operation`:
+
+```yaml
+nuclear_operation:
+  enabled: true
+  min_output: 0.20
+  ramp_limit: 0.025
+```
+
+The available settings are:
+
+- `enabled`: Enables the nuclear operating constraints. The default is
+  `false`.
+- `min_output`: Minimum nuclear output per unit of nominal capacity. It
+  must be between 0 and 1.
+- `ramp_limit`: Maximum increase or decrease in nuclear output between
+  adjacent snapshots, per unit of nominal capacity. It must be between
+  0 and 1.
+
+The configuration is applied to all generators whose carrier is
+`nuclear`.
+
+Ramp limits apply between consecutive snapshots rather than over a
+fixed period of time. For example, a value of `0.025` represents a
+maximum change of 2.5% of nominal capacity between snapshots. Its
+time-based interpretation therefore depends on the configured snapshot
+resolution.
+
+This configuration does not change generator capacity-expansion or
+unit-commitment settings. When a nuclear generator has
+`committable: false` and `min_output` is greater than zero, it remains
+online above the configured minimum. Start-up and shut-down decisions,
+minimum up/down times and cycling costs are not introduced.
+
+If `optimization.remove_must_run` is also enabled, existing minimum
+output constraints are first removed globally. The nuclear-specific
+`min_output` is then reapplied to nuclear generators.
 
 ### Market Dispatch
 

--- a/scripts/solve/solve_network.py
+++ b/scripts/solve/solve_network.py
@@ -17,6 +17,7 @@ from scripts.solve.hydro_constraints import (
     combine_extra_functionalities,
     log_hydro_constraint_setup,
 )
+from scripts.utilities.generator_operation import configure_nuclear
 
 # Fast I/O for network loading/saving
 from scripts.utilities.network_io import load_network, save_network
@@ -44,7 +45,6 @@ RENEWABLE_CARRIERS = {
     "marine",
     "geothermal",
 }
-
 
 def get_solve_mode_from_config() -> str:
     """
@@ -1954,6 +1954,93 @@ if __name__ == "__main__":
             else:
                 logger.info("No 'p_min_pu' column found - all generators can turn off")
         logger.info("=" * 80)
+
+        # Apply scenario specific nuclear operating assumptions
+        nuclear_config = scenario_config.get("nuclear_operation", {})
+
+        if nuclear_config.get("enabled", False):
+            if remove_must_run:
+                raise ValueError(
+                    "Conflicting configuration: nuclear_operation is "
+                    "enabled while optimization.remove_must_run is true."
+                )
+
+            required_parameters = {
+                "min_output",
+                "ramp_limit",
+            }
+
+            missing_parameters = (
+                    required_parameters - nuclear_config.keys()
+            )
+
+            if missing_parameters:
+                raise KeyError(
+                    "Missing nuclear-operation parameters: "
+                    f"{sorted(missing_parameters)}"
+                )
+
+            logger.info("=" * 80)
+            logger.info(
+                "APPLYING NUCLEAR OPERATING ASSUMPTIONS"
+            )
+            logger.info("=" * 80)
+            logger.info(
+                f"Minimum nuclear output: "
+                f"{nuclear_config['min_output']}"
+            )
+            logger.info(
+                f"Nuclear ramp limit: "
+                f"{nuclear_config['ramp_limit']}"
+            )
+
+            # Apply nuclear config
+            network = configure_nuclear(
+                network=network,
+                min_output=float(
+                    nuclear_config["min_output"]
+                ),
+                ramp_limit=float(
+                    nuclear_config["ramp_limit"]
+                ),
+            )
+
+            nuclear_mask = (
+                network.generators["carrier"]
+                .astype(str)
+                .str.strip()
+                .str.casefold()
+                .eq("nuclear")
+            )
+
+            logger.info(
+                f"Configured {nuclear_mask.sum()} "
+                "nuclear generators"
+            )
+
+            applied_values = (
+                network.generators.loc[
+                    nuclear_mask,
+                    [
+                        "p_min_pu",
+                        "ramp_limit_up",
+                        "ramp_limit_down",
+                    ],
+                ]
+                .drop_duplicates()
+                .to_dict(orient="records")
+            )
+
+            logger.info(
+                f"Applied nuclear values: {applied_values}"
+            )
+            logger.info("=" * 80)
+
+        else:
+            logger.info(
+                "No scenario-specific nuclear operating "
+                "configuration enabled"
+            )
         
         # Check generator aggregation status
         if hasattr(network, 'meta') and network.meta.get('aggregated', False):

--- a/scripts/utilities/generator_operation.py
+++ b/scripts/utilities/generator_operation.py
@@ -1,0 +1,79 @@
+import math
+import pypsa
+
+
+def _validate_per_unit_value(name: str, value: float) -> float:
+    """Validate and return a finite per-unit value."""
+
+    if isinstance(value, bool):
+        raise ValueError(f"{name} must be numeric, not boolean.")
+
+    try:
+        validated_value = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{name} must be numeric.") from exc
+
+    if not math.isfinite(validated_value):
+        raise ValueError(f"{name} must be finite.")
+
+    if not 0.0 <= validated_value <= 1.0:
+        raise ValueError(f"{name} must be between 0 and 1.")
+
+    return validated_value
+
+
+def configure_nuclear(
+        network: pypsa.Network,
+        min_output: float,
+        ramp_limit: float
+) -> pypsa.Network:
+    """
+    Apply static operating constraints to nuclear generators.
+
+    The minimum output and ramp limits are expressed per unit of nominal capacity.
+
+    This function currently does not introduce start-up/down decisions, minimum
+    up/down times or cycling costs.
+
+    Parameters
+    ----------
+    network: pypsa.Network
+        PyPSA network containing generators to configure.
+    min_output: float,
+        Minimum nuclear output per unit of nominal capacity,
+        in [0,1].
+    ramp_limit: float
+        Maximum increase/decrease between adjacent snapshots,
+        in [0,1].
+
+    Returns
+    -------
+    pypsa.Network
+        Network with nuclear operating constraints applied.
+        
+    Raises
+    ------
+    ValueError
+        If either value is invalid or no nuclear generators
+        are found.
+    """
+    min_output = _validate_per_unit_value("min_output", min_output)
+    ramp_limit = _validate_per_unit_value("ramp_limit", ramp_limit)
+
+    carriers = (
+        network.generators["carrier"]
+        .fillna("")
+        .astype(str)
+        .str.casefold()
+    )
+
+    nuclear = carriers.eq("nuclear")
+
+    if not nuclear.any():
+        raise ValueError("No nuclear generators found.")
+
+    network.generators.loc[nuclear, "p_min_pu"] = min_output
+    network.generators.loc[nuclear, "ramp_limit_up"] = ramp_limit
+    network.generators.loc[nuclear, "ramp_limit_down"] = ramp_limit
+
+    return network

--- a/tests/unit/test_generator_operation.py
+++ b/tests/unit/test_generator_operation.py
@@ -1,0 +1,195 @@
+import numpy as np
+import pandas as pd
+import pypsa
+import pytest
+
+from scripts.utilities.generator_operation import configure_nuclear
+
+
+@pytest.fixture
+def test_network() -> pypsa.Network:
+    """Create a small network containing nuclear and gas generators."""
+    network = pypsa.Network()
+    network.add("Bus", "bus")
+
+    network.add(
+        "Generator",
+        "nuclear_extendable",
+        bus="bus",
+        carrier="nuclear",
+        p_nom=1_000.0,
+        p_nom_extendable=True,
+        committable=False,
+        p_min_pu=0.0,
+    )
+
+    network.add(
+        "Generator",
+        "nuclear_committable",
+        bus="bus",
+        carrier="Nuclear",
+        p_nom=1_000.0,
+        p_nom_extendable=False,
+        committable=True,
+        p_min_pu=0.0,
+    )
+
+    network.add(
+        "Generator",
+        "gas",
+        bus="bus",
+        carrier="gas",
+        p_nom=1_000.0,
+        p_min_pu=0.1,
+        ramp_limit_up=0.5,
+        ramp_limit_down=0.4,
+    )
+
+    return network
+
+
+def test_configure_nuclear_applies_constraints(
+        test_network: pypsa.Network,
+) -> None:
+    """Nuclear generators should receive the configured constraints."""
+    result = configure_nuclear(
+        network=test_network,
+        min_output=0.2,
+        ramp_limit=0.025,
+    )
+
+    nuclear_names = [
+        "nuclear_extendable",
+        "nuclear_committable",
+    ]
+
+    np.testing.assert_allclose(
+        result.generators.loc[nuclear_names, "p_min_pu"],
+        0.2,
+    )
+    np.testing.assert_allclose(
+        result.generators.loc[nuclear_names, "ramp_limit_up"],
+        0.025,
+    )
+    np.testing.assert_allclose(
+        result.generators.loc[nuclear_names, "ramp_limit_down"],
+        0.025,
+    )
+
+    assert result is test_network
+
+
+def test_configure_nuclear_preserves_other_generators(
+        test_network: pypsa.Network,
+) -> None:
+    """Non-nuclear generators should remain unchanged."""
+    gas_before = test_network.generators.loc["gas"].copy()
+
+    configure_nuclear(
+        network=test_network,
+        min_output=0.2,
+        ramp_limit=0.025,
+    )
+
+    pd.testing.assert_series_equal(
+        test_network.generators.loc["gas"],
+        gas_before,
+    )
+
+
+def test_configure_nuclear_preserves_model_choices(
+        test_network: pypsa.Network,
+) -> None:
+    """Capacity-expansion and commitment choices should be preserved."""
+    extendable_before = test_network.generators[
+        "p_nom_extendable"
+    ].copy()
+    committable_before = test_network.generators[
+        "committable"
+    ].copy()
+
+    configure_nuclear(
+        network=test_network,
+        min_output=0.2,
+        ramp_limit=0.025,
+    )
+
+    pd.testing.assert_series_equal(
+        test_network.generators["p_nom_extendable"],
+        extendable_before,
+    )
+    pd.testing.assert_series_equal(
+        test_network.generators["committable"],
+        committable_before,
+    )
+
+
+@pytest.mark.parametrize(
+    ("min_output", "ramp_limit"),
+    [
+        (-0.01, 0.1),
+        (1.01, 0.1),
+        (0.1, -0.01),
+        (0.1, 1.01),
+        (np.nan, 0.1),
+        (0.1, np.nan),
+        (np.inf, 0.1),
+        (0.1, np.inf),
+        ("invalid", 0.1),
+        (0.1, "invalid"),
+        (True, 0.1),
+        (0.1, False),
+    ],
+)
+def test_configure_nuclear_rejects_invalid_values(
+        test_network: pypsa.Network,
+        min_output: object,
+        ramp_limit: object,
+) -> None:
+    """Invalid per-unit settings should raise a useful error."""
+    with pytest.raises(ValueError):
+        configure_nuclear(
+            network=test_network,
+            min_output=min_output,
+            ramp_limit=ramp_limit,
+        )
+
+
+@pytest.mark.parametrize(
+    ("min_output", "ramp_limit"),
+    [
+        (0.0, 0.0),
+        (1.0, 1.0),
+    ],
+)
+def test_configure_nuclear_accepts_boundary_values(
+        test_network: pypsa.Network,
+        min_output: float,
+        ramp_limit: float,
+) -> None:
+    """Zero and one should be valid inclusive boundary values."""
+    configure_nuclear(
+        network=test_network,
+        min_output=min_output,
+        ramp_limit=ramp_limit,
+    )
+
+
+def test_configure_nuclear_requires_nuclear_generators() -> None:
+    """Enabled nuclear configuration should not silently do nothing."""
+    network = pypsa.Network()
+    network.add("Bus", "bus")
+    network.add(
+        "Generator",
+        "gas",
+        bus="bus",
+        carrier="gas",
+        p_nom=1_000.0,
+    )
+
+    with pytest.raises(ValueError, match="nuclear generators"):
+        configure_nuclear(
+            network=network,
+            min_output=0.2,
+            ramp_limit=0.025,
+        )


### PR DESCRIPTION
Introduced a function configure nuclear operation constraints. The purpose of this is to model nuclear generators in a load-following mode.  This is done to allow for the simulation of a French style nuclear system on the GB grid. It doesn't capture the full operational requirements of flexible nuclear power but is a start.

There is also two additional scenarios included that use this function and are built on top of HT35-reduced.